### PR TITLE
Allow perl wrapper to use language-Country values

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -22,6 +22,7 @@ my $builder = Module::Build->new(
     build_requires     => {
         'Test::More' => 0,
         'Test::MockObject' => 0,
+        'Test::Exception' => 0,
         'version'    => 0,
     },
     requires => {

--- a/lib/TMDB/Session.pm
+++ b/lib/TMDB/Session.pm
@@ -16,6 +16,7 @@ use HTTP::Tiny qw();
 use URI::Encode qw();
 use Params::Validate qw(validate_with :types);
 use Locale::Codes::Language qw(all_language_codes);
+use Locale::Codes::Country qw(all_country_codes);
 use Object::Tiny qw(apikey apiurl lang debug client encoder json);
 
 #######################
@@ -29,6 +30,7 @@ our $VERSION = '1.2.1';
 
 # Valid language codes
 my %valid_lang_codes = map { $_ => 1 } all_language_codes('alpha-2');
+my %valid_country_codes = map { uc($_) => 1 } all_country_codes('alpha-2');
 
 # Default Headers
 my $default_headers = {
@@ -64,7 +66,11 @@ sub new {
                 optional  => 1,
                 callbacks => {
                     'valid language code' =>
-                      sub { $valid_lang_codes{ lc $_[0] } },
+                      sub { 
+                        my ( $lang, $country ) = split(/-/, ,$_[0]);
+                        $valid_lang_codes{ lc $lang } && !$country
+                        || $valid_lang_codes{ $lang } && $valid_country_codes{ $country };
+                      },
                 },
             },
             client => {
@@ -96,7 +102,7 @@ sub new {
         },
     );
 
-    $opts{lang} = lc $opts{lang} if $opts{lang};
+    $opts{lang} = lc $opts{lang} if $opts{lang} && length($opts{lang}) == 2;
     my $self = $class->SUPER::new(%opts);
   return $self;
 } ## end sub new

--- a/t/01-init.t
+++ b/t/01-init.t
@@ -16,13 +16,7 @@ local $| = 1;
 ok (TMDB->new( apikey => 'fake-api-key'), 'Initialize without language');
 ok (TMDB->new( apikey => 'fake-api-key', lang => 'en' ), 'Initialize with ISO 636-1 language code');
 ok (TMDB->new( apikey => 'fake-api-key', lang => 'EN' ), 'Initialize with ISO 636-1 language code upercase');
-
-TODO: {
-    todo_skip "Not implemented: mithun/perl-tmdb#12", 1;
-
-    ok (TMDB->new( apikey => 'fake-api-key', lang => 'en-US' ), 'Initialize with IETF language tag language');
-};
-
+ok (TMDB->new( apikey => 'fake-api-key', lang => 'en-US' ), 'Initialize with IETF language tag language');
 dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'country code part should be upercase';
 dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'language code part should be lovercase';
 

--- a/t/01-init.t
+++ b/t/01-init.t
@@ -1,0 +1,32 @@
+#!perl
+
+####################
+# LOAD CORE MODULES
+####################
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use Test::Exception;
+use TMDB;
+
+# Autoflush ON
+local $| = 1;
+
+# Test TMDB instance creation
+ok (TMDB->new( apikey => 'fake-api-key'), 'Initialize without language');
+ok (TMDB->new( apikey => 'fake-api-key', lang => 'en' ), 'Initialize with ISO 636-1 language code');
+ok (TMDB->new( apikey => 'fake-api-key', lang => 'EN' ), 'Initialize with ISO 636-1 language code upercase');
+
+TODO: {
+    todo_skip "Not implemented: mithun/perl-tmdb#12", 1;
+
+    ok (TMDB->new( apikey => 'fake-api-key', lang => 'en-US' ), 'Initialize with IETF language tag language');
+};
+
+dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'country code part should be upercase';
+dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'language code part should be lovercase';
+
+
+# Done
+done_testing();
+exit 0;


### PR DESCRIPTION
## What I've done

I relaxed the constraint on `Session` init `lang` parameter in order to accept either 
- an _ISO 639-1 language code_ or 
- a _language-Country_ value (e.g. `es-MX`).

## Why do that ?

1. All TMDB api requests accept values of type _ISO 639-1 code_ or a _language-Country_  for the `language` parameter.
2. Sometimes, TMDB content is different when you use _ISO 639-1 code_ or _language-Country_  (event if the language part is the same)
3. Most examples in TMDB API doc use _language-Country_ for the `language` parameter.

Fix mithun/perl-tmdb#12