### PR TITLE
Allow Perl Wraper to use Access Token or API key.

### DIFF
--- a/lib/TMDB/Session.pm
+++ b/lib/TMDB/Session.pm
@@ -17,7 +17,7 @@ use URI::Encode qw();
 use Params::Validate qw(validate_with :types);
 use Locale::Codes::Language qw(all_language_codes);
 use Locale::Codes::Country qw(all_country_codes);
-use Object::Tiny qw(apikey apiurl lang debug client encoder json);
+use Object::Tiny qw(_http_options token apikey apiurl lang debug client encoder json);
 
 #######################
 # VERSION
@@ -55,6 +55,19 @@ sub new {
         spec   => {
             apikey => {
                 type => SCALAR,
+                optional => 1,
+                default => undef,
+                callbacks => {
+                  'incompatible with token' => sub { $_[0] && ! $_[1]->{token} }
+                },
+            },
+            token => {
+                type => SCALAR,
+                optional => 1,
+                default => undef,
+                callbacks => {
+                  'incompatible with apikey' => sub { $_[0] && ! $_[1]->{apikey} }
+                },
             },
             apiurl => {
                 type     => SCALAR,
@@ -78,8 +91,7 @@ sub new {
                 isa      => 'HTTP::Tiny',
                 optional => 1,
                 default  => HTTP::Tiny->new(
-                    agent           => $default_ua,
-                    default_headers => $default_headers,
+                    agent => $default_ua,
                 ),
             },
             encoder => {
@@ -104,6 +116,10 @@ sub new {
 
     $opts{lang} = lc $opts{lang} if $opts{lang} && length($opts{lang}) == 2;
     my $self = $class->SUPER::new(%opts);
+
+    my $headers = $default_headers;
+    $headers->{Authorization} = 'Bearer '.($self->token) if $self->token;
+    $self->{_http_options} = { headers => $headers };
   return $self;
 } ## end sub new
 
@@ -114,16 +130,22 @@ sub talk {
     my ( $self, $args ) = @_;
 
     # Build Call
-    my $url
-      = $self->apiurl . '/' . $args->{method} . '?api_key=' . $self->apikey;
+    my $url = $self->apiurl . '/' . $args->{method};
+    $url .= '?api_key=' . $self->apikey if $self->apikey; 
     # add language by default
     $args->{params}->{language} = $self->lang unless (exists $args->{params}->{language});
     if ( $args->{params} ) {
+        my $firstparam = ! $self->apikey;
         foreach
           my $param ( sort { lc $a cmp lc $b } keys %{ $args->{params} } )
         {
           next unless defined $args->{params}->{$param};
+          if ($firstparam) {
+            $url .= "?${param}=" . $args->{params}->{$param};
+            $firstparam = 0;
+          } else {
             $url .= "&${param}=" . $args->{params}->{$param};
+          }
         } ## end foreach my $param ( sort { ...})
     } ## end if ( $args->{params} )
 
@@ -132,7 +154,7 @@ sub talk {
 
     # Talk
     warn "DEBUG: GET -> $url\n" if $self->debug;
-    my $response = $self->client->get($url);
+    my $response = $self->client->get($url, $self->_http_options);
 
     # Debug
     if ( $self->debug ) {

--- a/lib/TMDB/Session.pm
+++ b/lib/TMDB/Session.pm
@@ -80,7 +80,7 @@ sub new {
                 callbacks => {
                     'valid language code' =>
                       sub { 
-                        my ( $lang, $country ) = split(/-/, ,$_[0]);
+                        my ( $lang, $country ) = split(/-/, $_[0]);
                         $valid_lang_codes{ lc $lang } && !$country
                         || $valid_lang_codes{ $lang } && $valid_country_codes{ $country };
                       },

--- a/lib/TMDB/Session.pm
+++ b/lib/TMDB/Session.pm
@@ -117,7 +117,7 @@ sub new {
     $opts{lang} = lc $opts{lang} if $opts{lang} && length($opts{lang}) == 2;
     my $self = $class->SUPER::new(%opts);
 
-    my $headers = $default_headers;
+    my $headers = { %$default_headers };
     $headers->{Authorization} = 'Bearer '.($self->token) if $self->token;
     $self->{_http_options} = { headers => $headers };
   return $self;

--- a/lib/TMDB/Session.pm
+++ b/lib/TMDB/Session.pm
@@ -58,7 +58,7 @@ sub new {
                 optional => 1,
                 default => undef,
                 callbacks => {
-                  'incompatible with token' => sub { $_[0] && ! $_[1]->{token} }
+                  'incompatible with token' => sub { !($_[0] && $_[1]->{token}) }
                 },
             },
             token => {

--- a/lib/TMDB/Session.pm
+++ b/lib/TMDB/Session.pm
@@ -66,7 +66,7 @@ sub new {
                 optional => 1,
                 default => undef,
                 callbacks => {
-                  'incompatible with apikey' => sub { $_[0] && ! $_[1]->{apikey} }
+                  'incompatible with apikey' => sub { !($_[0] && $_[1]->{apikey}) }
                 },
             },
             apiurl => {

--- a/t/01-init.t
+++ b/t/01-init.t
@@ -19,7 +19,12 @@ ok (TMDB->new( apikey => 'fake-api-key', lang => 'EN' ), 'Initialize with ISO 63
 ok (TMDB->new( apikey => 'fake-api-key', lang => 'en-US' ), 'Initialize with IETF language tag language');
 dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'country code part should be upercase';
 dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'language code part should be lovercase';
+ok (!TMDB->new( apikey => 'fake-api-key')->session->_http_options->{headers}->{Authorization}, 'No Authorization header in HTTP options');
 
+# Test with access-token
+ok ok (TMDB->new( token => 'fake-token'), 'Initialize with a token');
+is (TMDB->new( token => 'fake-token')->session->_http_options->{headers}->{Authorization}, "Bearer fake-token", "Presence of Authorization header in HTTP options");
+dies_ok { TMDB->new( apikey => 'fake-api-key', token => 'fake-token' ) } 'Should not have an apikey and a token simultaneously';
 
 # Done
 done_testing();

--- a/t/01-init.t
+++ b/t/01-init.t
@@ -22,7 +22,7 @@ dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'language cod
 ok (!TMDB->new( apikey => 'fake-api-key')->session->_http_options->{headers}->{Authorization}, 'No Authorization header in HTTP options');
 
 # Test with access-token
-ok ok (TMDB->new( token => 'fake-token'), 'Initialize with a token');
+ok (TMDB->new( token => 'fake-token'), 'Initialize with a token');
 is (TMDB->new( token => 'fake-token')->session->_http_options->{headers}->{Authorization}, "Bearer fake-token", "Presence of Authorization header in HTTP options");
 dies_ok { TMDB->new( apikey => 'fake-api-key', token => 'fake-token' ) } 'Should not have an apikey and a token simultaneously';
 

--- a/t/01-init.t
+++ b/t/01-init.t
@@ -20,11 +20,35 @@ ok (TMDB->new( apikey => 'fake-api-key', lang => 'en-US' ), 'Initialize with IET
 dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'country code part should be upercase';
 dies_ok { TMDB->new( apikey => 'fake-api-key', lang => 'en-us' ) } 'language code part should be lovercase';
 ok (!TMDB->new( apikey => 'fake-api-key')->session->_http_options->{headers}->{Authorization}, 'No Authorization header in HTTP options');
+is (TMDB->new( apikey => 'fake-api-key')->session->apikey, 'fake-api-key', 'Session::apikey contains the api key');
 
 # Test with access-token
 ok (TMDB->new( token => 'fake-token'), 'Initialize with a token');
 is (TMDB->new( token => 'fake-token')->session->_http_options->{headers}->{Authorization}, "Bearer fake-token", "Presence of Authorization header in HTTP options");
+ok (!(TMDB->new( token => 'fake-token')->session->apikey), "No api key");
+
+# Test with both api key and access token
 dies_ok { TMDB->new( apikey => 'fake-api-key', token => 'fake-token' ) } 'Should not have an apikey and a token simultaneously';
+
+# Test with api_key and empty access-token
+ok (TMDB->new( apikey => 'fake-api-key', token => '' ), 'Initialize with api_key and empty access-token');
+is (TMDB->new( apikey => 'fake-api-key', token => '' )->session->apikey, 'fake-api-key', 'Session::apikey contains the api key');
+ok (!(TMDB->new( apikey => 'fake-api-key', token => '' )->session->_http_options->{headers}->{Authorization}), "No Bearer token in HTTP options");
+
+# Test with access-token and empty api_key
+ok (TMDB->new( apikey => '', token => 'fake-token' ), 'Initialize with empty api_key and access-token');
+is (TMDB->new( apikey => '', token => 'fake-token' )->session->_http_options->{headers}->{Authorization}, "Bearer fake-token", "Presence of Authorization header in HTTP options");
+ok (!(TMDB->new( apikey => '', token => 'fake-token' )->session->apikey), "No api key");
+
+# Test without api key and without access-token
+ok (TMDB->new( ), 'Initialize without api key and without access-token');
+ok (!(TMDB->new( )->session->_http_options->{headers}->{Authorization}), "No Bearer token in HTTP options");
+ok (!(TMDB->new( )->session->apikey), "No api key");
+
+# Test with empty api_key and empty access-token
+ok (TMDB->new( apikey => '', token => '' ), 'Initialize with empty api_key and empty access-token');
+ok (!(TMDB->new( apikey => '', token => '' )->session->_http_options->{headers}->{Authorization}), "No Bearer token in HTTP options");
+ok (!(TMDB->new( apikey => '', token => '' )->session->apikey), "No api key");
 
 # Done
 done_testing();

--- a/t/02-auth.t
+++ b/t/02-auth.t
@@ -26,7 +26,6 @@ $mock->set_always(
 );
 
 my ($tmdb, $name, $args, $url, $opts);
-my $http_options = 
 
 # Test apikey is send as query string parameter
 $mock->clear;

--- a/t/02-auth.t
+++ b/t/02-auth.t
@@ -49,6 +49,52 @@ $opts = @$args[2];
 is ($url, "https://api.themoviedb.org/3/test/path?para1=v1&para2=v2", "There is no API key in query-string parameters");
 is ($opts->{headers}->{Authorization}, "Bearer fake-api-token", "Presence of Authorization header in HTTP options");
 
+# Tests when apikey or token is empty
+# Test when token is empty
+$mock->clear;
+$tmdb = TMDB->new( apikey => 'fake-api-key', token=> '', client => $mock );
+$tmdb->{session}->talk( { method => "test/path", params => { para1 => "v1", para2 => "v2" } } );
+($name, $args) = $mock->next_call();
+$url = @$args[1];
+$opts = @$args[2];
+
+is ($url, "https://api.themoviedb.org/3/test/path?api_key=fake-api-key&para1=v1&para2=v2", "API key is passed as query-string parameter");
+ok (!$opts->{headers}->{Authorization}, 'No Authorization header in HTTP options');
+
+# Test when apikey is empty
+$mock->clear;
+$tmdb = TMDB->new( apikey => '', token => 'fake-api-token', client => $mock );
+$tmdb->{session}->talk( { method => "test/path", params => { para1 => "v1", para2 => "v2" } } );
+($name, $args) = $mock->next_call();
+$url = @$args[1];
+$opts = @$args[2];
+
+is ($url, "https://api.themoviedb.org/3/test/path?para1=v1&para2=v2", "There is no API key in query-string parameters");
+is ($opts->{headers}->{Authorization}, "Bearer fake-api-token", "Presence of Authorization header in HTTP options");
+
+# Test when apikey and token are empty
+$mock->clear;
+$tmdb = TMDB->new( apikey => '', token => '', client => $mock );
+$tmdb->{session}->talk( { method => "test/path", params => { para1 => "v1", para2 => "v2" } } );
+($name, $args) = $mock->next_call();
+$url = @$args[1];
+$opts = @$args[2];
+
+is ($url, "https://api.themoviedb.org/3/test/path?para1=v1&para2=v2", "There is no API key in query-string parameters");
+ok (!$opts->{headers}->{Authorization}, 'No Authorization header in HTTP options');
+
+# Test without apikey and without token
+$mock->clear;
+$tmdb = TMDB->new( client => $mock );
+$tmdb->{session}->talk( { method => "test/path", params => { para1 => "v1", para2 => "v2" } } );
+($name, $args) = $mock->next_call();
+$url = @$args[1];
+$opts = @$args[2];
+
+is ($url, "https://api.themoviedb.org/3/test/path?para1=v1&para2=v2", "There is no API key in query-string parameters");
+ok (!$opts->{headers}->{Authorization}, 'No Authorization header in HTTP options');
+
+
 # Done
-done_testing(4);
+done_testing(12);
 exit 0;

--- a/t/02-auth.t
+++ b/t/02-auth.t
@@ -1,0 +1,55 @@
+#!perl
+
+####################
+# LOAD CORE MODULES
+####################
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+use Test::MockObject;
+use TMDB;
+use HTTP::Tiny;
+
+# Autoflush ON
+local $| = 1;
+
+
+my $mock = Test::MockObject->new;
+$mock->set_isa('HTTP::Tiny');
+$mock->set_always( 
+    'get',
+    {   success => 1,
+        status => 200,
+        headers => {},
+        content => '{ "id": 1234, "results": [], "changes": [], "title": "blabla", "name": "blabla", "overview": "blabla blabla", "credits": { "cast": [], "crew": [] }}'
+    }
+);
+
+my ($tmdb, $name, $args, $url, $opts);
+my $http_options = 
+
+# Test apikey is send as query string parameter
+$mock->clear;
+$tmdb = TMDB->new( apikey => 'fake-api-key', client => $mock);
+$tmdb->{session}->talk( { method => "test/path", params => { para1 => "v1", para2 => "v2" } } );
+($name, $args) = $mock->next_call();
+$url = @$args[1];
+$opts = @$args[2];
+
+is ($url, "https://api.themoviedb.org/3/test/path?api_key=fake-api-key&para1=v1&para2=v2", "API key is passed as query-string parameter");
+ok (!$opts->{headers}->{Authorization}, 'No Authorization header in HTTP options');
+
+# Test token is sent in headers as Bearer token
+$mock->clear;
+$tmdb = TMDB->new( token => 'fake-api-token', client => $mock);
+$tmdb->{session}->talk( { method => "test/path", params => { para1 => "v1", para2 => "v2" } } );
+($name, $args) = $mock->next_call();
+$url = @$args[1];
+$opts = @$args[2];
+
+is ($url, "https://api.themoviedb.org/3/test/path?para1=v1&para2=v2", "There is no API key in query-string parameters");
+is ($opts->{headers}->{Authorization}, "Bearer fake-api-token", "Presence of Authorization header in HTTP options");
+
+# Done
+done_testing(4);
+exit 0;


### PR DESCRIPTION
With this PR, the perl wrapper can now be created either with an _API Key_ or an _Access Token_.

If an Access Token is used, the token now is sent in the Authorization header of the request, while the API Key is still sent as a query-string parameter.

As explained in the[ TMDB API docs](https://developer.themoviedb.org/docs/authentication-application), the API Key and the Access Token provides the same access level to the _TMDB API_.